### PR TITLE
changed array shorthand `[]` to `array()` for 5.3 compliance

### DIFF
--- a/src/Criteria.php
+++ b/src/Criteria.php
@@ -72,7 +72,7 @@ class Criteria
      */
     public function getSort()
     {
-        $sort = [];
+        $sort = array();
 
         $fields = explode(',', $this->getInput('sort'));
 

--- a/src/Document.php
+++ b/src/Document.php
@@ -11,14 +11,12 @@
 
 namespace Tobscure\JsonApi;
 
-use JsonSerializable;
-
 /**
  * This is the document class.
  *
  * @author Toby Zerner <toby.zerner@gmail.com>
  */
-class Document implements JsonSerializable
+class Document
 {
     /**
      * The links array.
@@ -219,15 +217,5 @@ class Document implements JsonSerializable
     public function __toString()
     {
         return json_encode($this->toArray());
-    }
-
-    /**
-     * Serialize for JSON usage.
-     *
-     * @return array
-     */
-    public function jsonSerialize()
-    {
-        return $this->toArray();
     }
 }


### PR DESCRIPTION
Just a small change but it was breaking the code on the php5.3 system on which we want want to build an api.
